### PR TITLE
Bump to latest

### DIFF
--- a/org.gnome.Reversi.json
+++ b/org.gnome.Reversi.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.Reversi",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "41",
+    "runtime-version" : "43",
     "sdk" : "org.gnome.Sdk",
     "command" : "iagno",
     "finish-args" : [
@@ -44,7 +44,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/iagno.git",
-                    "commit": "19bf5142d77d9c8241ca7511adcfef8e12fc77fb"
+                    "commit": "ba5a540484796e2f0a4379d656aa1e3b174f6da8"
                   }
             ]
         }

--- a/org.gnome.Reversi.json
+++ b/org.gnome.Reversi.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.Reversi",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "command" : "iagno",
     "finish-args" : [


### PR DESCRIPTION
Closes #6

Updated to gnome 44 runtime, as 41 is deprecated.
The version from the old commit hash didn't build, so I updated it too. (I believe, the old hash was also just the most up-to-date one at that time)
I also updated the shared modules for good measure (cleans up more stuff from libcanberra, that isn't needed at runtime).

I tested it and played one game.